### PR TITLE
Fix syntax error in livemap service

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/LivemapService.java
+++ b/app/src/main/java/com/cooper/wheellog/LivemapService.java
@@ -97,7 +97,7 @@ public class LivemapService extends Service {
         return instance != null;
     }
     public static LivemapService getInstance() { return instance; }
-7    public static double getDistance() { return currentDistance / 1000; }
+    public static double getDistance() { return currentDistance / 1000; }
     public static double getSpeed() { return (livemapGPS) ? currentSpeed : 0; }
     public static LivemapStatus getStatus() { return status; }
     public static String getUrl() { return url; }


### PR DESCRIPTION
Fixed stray '7' at head of line among error declarations in livemap service causing build failure