### PR TITLE
Edit userdist

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/LivemapService.java
+++ b/app/src/main/java/com/cooper/wheellog/LivemapService.java
@@ -97,7 +97,7 @@ public class LivemapService extends Service {
         return instance != null;
     }
     public static LivemapService getInstance() { return instance; }
-7    public static double getDistance() { return currentDistance / 1000; }
+    public static double getDistance() { return currentDistance / 1000; }
     public static double getSpeed() { return (livemapGPS) ? currentSpeed : 0; }
     public static LivemapStatus getStatus() { return status; }
     public static String getUrl() { return url; }

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -36,7 +36,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
         Watch,
 		Wheel
     }
-	
+
 	WHEEL_TYPE mWheelType = WHEEL_TYPE.Unknown;
 
     private boolean mDataWarningDisplayed = false;
@@ -99,97 +99,94 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                 break;
             case "use_mi":
                 getActivity().sendBroadcast(new Intent(Constants.ACTION_PEBBLE_AFFECTING_PREFERENCE_CHANGED));
-                break;			
+                break;
             case "max_speed":
                 getActivity().sendBroadcast(new Intent(Constants.ACTION_PEBBLE_AFFECTING_PREFERENCE_CHANGED));
                 break;
-			case "light_enabled":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_LIGHT, true));
-				boolean ligth_enabled = sharedPreferences.getBoolean(getString(R.string.light_enabled), false);
-				WheelData.getInstance().updateLight(ligth_enabled);
-				break;
-			case "led_enabled":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_LED, true));
-				boolean led_enabled = sharedPreferences.getBoolean(getString(R.string.led_enabled), false);
-				WheelData.getInstance().updateLed(led_enabled);
-				break;
-			case "handle_button_disabled":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_BUTTON, true));
-				boolean handle_button_disabled = sharedPreferences.getBoolean(getString(R.string.handle_button_disabled), false);
-				WheelData.getInstance().updateHandleButton(handle_button_disabled);
-				break;
-			case "wheel_max_speed":
-				//if (!mSpeedWarningDisplayed) {
-				final int max_speed = sharedPreferences.getInt(getString(R.string.wheel_max_speed), 0);
-				WheelData.getInstance().updateMaxSpeed(max_speed);
-				//	if (max_speed > 30)  {
-				//		new AlertDialog.Builder(getActivity())
-				//			.setTitle("Are you sure?")
-				//			.setMessage("Setting a speed limit higher than 30 km/h is unsafe, this is an undocumented feature. \n\nUSE IT ON YOUR OWN RISK! \n\nNeither the Inmotion Company nor the developers of this application are liable for any damages to your health, EUC or third party resulting by using of this feature.")
-				//			.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
-				//				public void onClick(DialogInterface dialog, int which) {									
-				//					WheelData.getInstance().updateMaxSpeed(max_speed);
-				//				}
-				//			})
-				//			.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
-				//				public void onClick(DialogInterface dialog, int which) {									
-				//					mSpeedWarningDisplayed = true;
-				//					correctWheelBarState(getString(R.string.wheel_max_speed), WheelData.getInstance().getWheelMaxSpeed());
-				//					
-				//				}
-				//			})
-				//			.setIcon(android.R.drawable.ic_dialog_alert)
-				//			.show();
-	
-				//	} else {
-				//		//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_MAX_SPEED, true));
-				//		WheelData.getInstance().updateMaxSpeed(max_speed);
-				//	}
-				//} else mSpeedWarningDisplayed = false;
-				
-				break;
-			case "speaker_volume":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_SPEAKER_VOLUME, true));
-				int speaker_volume = sharedPreferences.getInt(getString(R.string.speaker_volume), 0);
-				WheelData.getInstance().updateSpeakerVolume(speaker_volume);
-				break;
-			case "pedals_adjustment":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_PEDALS_ADJUSTMENT, true));
-				int pedals_adjustment = sharedPreferences.getInt(getString(R.string.pedals_adjustment), 0);
-				WheelData.getInstance().updatePedals(pedals_adjustment);
-				break;
-			case "pedals_mode":
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_PEDALS_ADJUSTMENT, true));
-				int pedals_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.pedals_mode), "0"));
-				WheelData.getInstance().updatePedalsMode(pedals_mode);
-				break;
-			case "light_mode":
-				int light_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.light_mode), "0"));
-				WheelData.getInstance().updateLightMode(light_mode);
-				break;
-			case "alarm_mode":
-				int alarm_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.alarm_mode), "0"));
-				WheelData.getInstance().updateAlarmMode(alarm_mode);
-				break;
-			case "strobe_mode":
-				int strobe_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.strobe_mode), "0"));
-				WheelData.getInstance().updateStrobe(strobe_mode);
-				break;
-			case "led_mode":
-				int led_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.led_mode), "0"));
-				WheelData.getInstance().updateLedMode(led_mode);
-				break;
-//			case "reset_user_trip":				
-//				WheelData.getInstance().resetUserDistance();
-//				break;
-//			case "reset_max_speed":				
-//				WheelData.getInstance().resetTopSpeed();
-//				break;
+            case "light_enabled":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_LIGHT, true));
+                boolean ligth_enabled = sharedPreferences.getBoolean(getString(R.string.light_enabled), false);
+                WheelData.getInstance().updateLight(ligth_enabled);
+                break;
+            case "led_enabled":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_LED, true));
+                boolean led_enabled = sharedPreferences.getBoolean(getString(R.string.led_enabled), false);
+                WheelData.getInstance().updateLed(led_enabled);
+                break;
+            case "handle_button_disabled":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_BUTTON, true));
+                boolean handle_button_disabled = sharedPreferences.getBoolean(getString(R.string.handle_button_disabled), false);
+                WheelData.getInstance().updateHandleButton(handle_button_disabled);
+                break;
+            case "wheel_max_speed":
+                //if (!mSpeedWarningDisplayed) {
+                final int max_speed = sharedPreferences.getInt(getString(R.string.wheel_max_speed), 0);
+                WheelData.getInstance().updateMaxSpeed(max_speed);
+                //  if (max_speed > 30)  {
+                //      new AlertDialog.Builder(getActivity())
+                //          .setTitle("Are you sure?")
+                //          .setMessage("Setting a speed limit higher than 30 km/h is unsafe, this is an undocumented feature. \n\nUSE IT ON YOUR OWN RISK! \n\nNeither the Inmotion Company nor the developers of this application are liable for any damages to your health, EUC or third party resulting by using of this feature.")
+                //          .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                //              public void onClick(DialogInterface dialog, int which) {                                    
+                //                  WheelData.getInstance().updateMaxSpeed(max_speed);
+                //              }
+                //          })
+                //          .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+                //              public void onClick(DialogInterface dialog, int which) {                                    
+                //                  mSpeedWarningDisplayed = true;
+                //                  correctWheelBarState(getString(R.string.wheel_max_speed), WheelData.getInstance().getWheelMaxSpeed());
+                //              }
+                //          })
+                //          .setIcon(android.R.drawable.ic_dialog_alert)
+                //          .show();
+
+                //  } else {
+                //      //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_MAX_SPEED, true));
+                //      WheelData.getInstance().updateMaxSpeed(max_speed);
+                //  }
+                //} else mSpeedWarningDisplayed = false;
+
+                break;
+            case "speaker_volume":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_SPEAKER_VOLUME, true));
+                int speaker_volume = sharedPreferences.getInt(getString(R.string.speaker_volume), 0);
+                WheelData.getInstance().updateSpeakerVolume(speaker_volume);
+                break;
+            case "pedals_adjustment":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_PEDALS_ADJUSTMENT, true));
+                int pedals_adjustment = sharedPreferences.getInt(getString(R.string.pedals_adjustment), 0);
+                WheelData.getInstance().updatePedals(pedals_adjustment);
+                break;
+            case "pedals_mode":
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING_CHANGED).putExtra(Constants.INTENT_EXTRA_WHEEL_PEDALS_ADJUSTMENT, true));
+                int pedals_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.pedals_mode), "0"));
+                WheelData.getInstance().updatePedalsMode(pedals_mode);
+                break;
+            case "light_mode":
+                int light_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.light_mode), "0"));
+                WheelData.getInstance().updateLightMode(light_mode);
+                break;
+            case "alarm_mode":
+                int alarm_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.alarm_mode), "0"));
+                WheelData.getInstance().updateAlarmMode(alarm_mode);
+                break;
+            case "strobe_mode":
+                int strobe_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.strobe_mode), "0"));
+                WheelData.getInstance().updateStrobe(strobe_mode);
+                break;
+            case "led_mode":
+                int led_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.led_mode), "0"));
+                WheelData.getInstance().updateLedMode(led_mode);
+                break;
+//          case "reset_user_trip":
+//              WheelData.getInstance().resetUserDistance();
+//              break;
+//          case "reset_max_speed":
+//              WheelData.getInstance().resetTopSpeed();
+//              break;
         }
         getActivity().sendBroadcast(new Intent(Constants.ACTION_PREFERENCE_CHANGED));
     }
-	
-
 
     private void setup_screen() {
         Toolbar tb = (Toolbar) getActivity().findViewById(R.id.preference_toolbar);
@@ -214,7 +211,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                 }
             });
         }
-		
 
         switch (currentScreen) {
             case Main:
@@ -225,14 +221,14 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                 Preference alarm_button = findPreference(getString(R.string.alarm_preferences));
                 Preference speech_button = findPreference(getString(R.string.speech_preferences));
                 Preference watch_button = findPreference(getString(R.string.watch_preferences));
-				Preference wheel_button = findPreference(getString(R.string.wheel_settings));
-				Preference reset_top_button = findPreference(getString(R.string.reset_top_speed));
-				Preference reset_user_distance_button = findPreference(getString(R.string.reset_user_distance));
+                Preference wheel_button = findPreference(getString(R.string.wheel_settings));
+                Preference reset_top_button = findPreference(getString(R.string.reset_top_speed));
+                Preference reset_user_distance_button = findPreference(getString(R.string.reset_user_distance));
+                Preference edit_user_distance_button = findPreference(getString(R.string.edit_user_distance));
                 Preference last_mac_button = findPreference(getString(R.string.last_mac));
                 Preference about_button = findPreference(getString(R.string.about));
-				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING).putExtra(Constants.INTENT_EXTRA_WHEEL_UPDATE_SCALE, 1));
+                //getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING).putExtra(Constants.INTENT_EXTRA_WHEEL_UPDATE_SCALE, 1));
 
-				
                 if (speed_button != null) {
                     speed_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
@@ -244,7 +240,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                             return true;
                         }
                     });
-                }
+                 }
                 if (logs_button != null) {
                     logs_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
@@ -305,73 +301,113 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                         }
                     });
                 }
-		        if (wheel_button != null) {
+                if (wheel_button != null) {
                     wheel_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {
                             currentScreen = SettingsScreen.Wheel;
                             getPreferenceScreen().removeAll();
                             if (mWheelType == WHEEL_TYPE.NINEBOT_Z) addPreferencesFromResource(R.xml.preferences_ninebot_z);
-							if (mWheelType == WHEEL_TYPE.INMOTION) addPreferencesFromResource(R.xml.preferences_inmotion);
-							if (mWheelType == WHEEL_TYPE.KINGSONG) addPreferencesFromResource(R.xml.preferences_kingsong);
-							if (mWheelType == WHEEL_TYPE.GOTWAY) {
-							//if (mWheelType == WHEEL_TYPE.INMOTION) {
-								addPreferencesFromResource(R.xml.preferences_gotway);
-								Preference start_calibration_button = findPreference(getString(R.string.start_calibration));
-								if (start_calibration_button != null) {
-									start_calibration_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-										@Override
-										public boolean onPreferenceClick(Preference preference) {                            
-											WheelData.getInstance().updateCalibration();
-											return true;
-										}
-									});
-								}
-							}
-							//addPreferencesFromResource(R.xml.preferences_gotway);
-							
+                            if (mWheelType == WHEEL_TYPE.INMOTION) addPreferencesFromResource(R.xml.preferences_inmotion);
+                            if (mWheelType == WHEEL_TYPE.KINGSONG) addPreferencesFromResource(R.xml.preferences_kingsong);
+                            if (mWheelType == WHEEL_TYPE.GOTWAY) {
+                            //if (mWheelType == WHEEL_TYPE.INMOTION) {
+                                addPreferencesFromResource(R.xml.preferences_gotway);
+                                Preference start_calibration_button = findPreference(getString(R.string.start_calibration));
+                                if (start_calibration_button != null) {
+                                    start_calibration_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                                        @Override
+                                        public boolean onPreferenceClick(Preference preference) {                            
+                                            WheelData.getInstance().updateCalibration();
+                                            return true;
+                                        }
+	                                    });
+                                }
+                            }
+                            //addPreferencesFromResource(R.xml.preferences_gotway);
+
                             setup_screen();
                             return true;
                         }
                     });
                 }
-				if (reset_top_button != null) {
+                if (reset_top_button != null) {
                     reset_top_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {
-							WheelData.getInstance().resetTopSpeed();
+                            WheelData.getInstance().resetTopSpeed();
                             return true;
                         }
                     });
                 }
-				if (reset_user_distance_button != null) {
+                if (reset_user_distance_button != null) {
                     reset_user_distance_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {                            
-							WheelData.getInstance().resetUserDistance();
+                            WheelData.getInstance().resetUserDistance();
                             return true;
                         }
                     });
                 }
-                if (about_button != null) {
-                    about_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+<<<<<<< HEAD
+                if (edit_user_distance_button != null) {
+                    edit_user_distance_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {
-                            showAboutDialog();
+                            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                            builder.setTitle(R.string.userdist_edit_type);
+                            final EditText input = new EditText(getActivity());
+                            input.setInputType(InputType.TYPE_CLASS_TEXT);
+                            input.setText(SettingsUtil.getUserDistance(getActivity(), SettingsUtil.getLastAddress(getActivity())));
+=======
+				if (edit_user_distance_button != null) {
+                        public boolean onPreferenceClick(Preference preference) {
+                            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                            builder.setTitle(R.string.userdist_edit_type);
+
+                            final EditText input = new EditText(getActivity());
+                            input.setInputType(InputType.TYPE_CLASS_TEXT);
+                            input.setText(SettingsUtil.getUserDistance(getActivity()), SettingsUtil.getLastAddress(getActivity()));
+>>>>>>> 148ee42... Introduce feature to edit user distance
+                            builder.setView(input);
+                            builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+<<<<<<< HEAD
+                                    final long originalDistance = Long.parseLong(input.getText().toString());
+=======
+	                                final long originalDistance = Long.parseLong(input.getText().toString());
+>>>>>>> 148ee42... Introduce feature to edit user distance
+                                    WheelData.getInstance().editUserDistance(originalDistance);
+                                }
+                            });
+                            builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    dialog.cancel();
+                                }
+                            });
+                            builder.show();
+<<<<<<< HEAD
                             return true;
                         }
                     });
                 }
+=======
 
 
+                            return true;
+                        }
 
+                    });
+				}
+>>>>>>> 148ee42... Introduce feature to edit user distance
                 if (last_mac_button != null) {
                     last_mac_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {
                             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                             builder.setTitle(R.string.mac_edit_type);
-
                             final EditText input = new EditText(getActivity());
                             input.setInputType(InputType.TYPE_CLASS_TEXT);
                             input.setText(SettingsUtil.getLastAddress(getActivity()));
@@ -383,7 +419,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                                     SettingsUtil.setLastAddress(getActivity(), deviceAddress);
                                     AlertDialog.Builder builder1 = new AlertDialog.Builder(getActivity());
                                     builder1.setTitle(R.string.wheel_password);
-
                                     final EditText input1 = new EditText(getActivity());
                                     input1.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
                                     builder1.setView(input1);
@@ -408,9 +443,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                                         }
                                     });
                                     builder1.show();
-
-
-
                                     //SettingsUtil.setPasswordForWheel(getActivity(), deviceAddress, "000000");
                                     //finish();
                                 }
@@ -423,11 +455,26 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                                 }
                             });
                             builder.show();
-
-
                             return true;
                         }
-
+                    });
+                }
+                if (about_button != null) {
+                    about_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                        @Override
+                        public boolean onPreferenceClick(Preference preference) {
+                            showAboutDialog();
+                            return true;
+                        }
+                    });
+                }
+	                if (about_button != null) {
+                    about_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                        @Override
+                        public boolean onPreferenceClick(Preference preference) {
+                            showAboutDialog();
+                            return true;
+                        }
                     });
                 }
 

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -325,7 +325,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                                 }
                             }
                             //addPreferencesFromResource(R.xml.preferences_gotway);
-
                             setup_screen();
                             return true;
                         }
@@ -349,7 +348,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                         }
                     });
                 }
-<<<<<<< HEAD
                 if (edit_user_distance_button != null) {
                     edit_user_distance_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
@@ -358,26 +356,12 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                             builder.setTitle(R.string.userdist_edit_type);
                             final EditText input = new EditText(getActivity());
                             input.setInputType(InputType.TYPE_CLASS_TEXT);
-                            input.setText(SettingsUtil.getUserDistance(getActivity(), SettingsUtil.getLastAddress(getActivity())));
-=======
-				if (edit_user_distance_button != null) {
-                        public boolean onPreferenceClick(Preference preference) {
-                            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                            builder.setTitle(R.string.userdist_edit_type);
-
-                            final EditText input = new EditText(getActivity());
-                            input.setInputType(InputType.TYPE_CLASS_TEXT);
-                            input.setText(SettingsUtil.getUserDistance(getActivity()), SettingsUtil.getLastAddress(getActivity()));
->>>>>>> 148ee42... Introduce feature to edit user distance
+                            input.setText(Long.toString(SettingsUtil.getUserDistance(getActivity(),SettingsUtil.getLastAddress(getActivity()))));
                             builder.setView(input);
                             builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
-<<<<<<< HEAD
                                     final long originalDistance = Long.parseLong(input.getText().toString());
-=======
-	                                final long originalDistance = Long.parseLong(input.getText().toString());
->>>>>>> 148ee42... Introduce feature to edit user distance
                                     WheelData.getInstance().editUserDistance(originalDistance);
                                 }
                             });
@@ -388,20 +372,10 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                                 }
                             });
                             builder.show();
-<<<<<<< HEAD
                             return true;
                         }
                     });
                 }
-=======
-
-
-                            return true;
-                        }
-
-                    });
-				}
->>>>>>> 148ee42... Introduce feature to edit user distance
                 if (last_mac_button != null) {
                     last_mac_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
@@ -468,7 +442,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                         }
                     });
                 }
-	                if (about_button != null) {
+                if (about_button != null) {
                     about_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                         @Override
                         public boolean onPreferenceClick(Preference preference) {

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -599,6 +599,7 @@ public class WheelData {
 
 	public void editUserDistance(long originalDistance) {		
 			SettingsUtil.setUserDistance(mContext, mBluetoothLeService.getBluetoothDeviceAddress(), originalDistance);
+			mUserDistance = originalDistance;
 	}
 	
 	public void resetTopSpeed() {

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -595,13 +595,15 @@ public class WheelData {
 			SettingsUtil.setUserDistance(mContext, mBluetoothLeService.getBluetoothDeviceAddress(), mTotalDistance);
 			mUserDistance = mTotalDistance;
 		}
+	}
 
-    }
+	public void editUserDistance(long originalDistance) {		
+			SettingsUtil.setUserDistance(mContext, mBluetoothLeService.getBluetoothDeviceAddress(), originalDistance);
+	}
 	
 	public void resetTopSpeed() {
 		mTopSpeed = 0;
     }
-	
 
     public double getDistanceDouble() {
         return ((mTotalDistance - mStartTotalDistance) * SettingsUtil.getDistCorrectionFactor(mContext)) / 1000.0;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
 	// TRIP PREFERENCES
 	<string name="reset_top_speed" translatable="false">reset_top_speed</string>
 	<string name="reset_user_distance" translatable="false">reset_user_distance</string>
+	<string name="edit_user_distance" translatable="false">edit_user_distance</string>
     <string name="last_mac" translatable="false">last_mac</string>
     <string name="about" translatable="false">about</string>
 
@@ -219,6 +220,7 @@
     <string name="last_mac_title">Edit MAC address</string>
     <string name="about_title">About WheelLog</string>
     <string name="reset_user_distance_title">Reset user distance</string>
+    <string name="edit_user_distance_title">Edit user distance</string>
     <string name="reset_top_speed_title">Reset top speed</string>
     <string name="wheel_settings_title">Wheel settings</string>
     <string name="watch_preferences_title">Watch preferences</string>
@@ -308,6 +310,7 @@
     <string name="no_settings_title">Wheel settings for Ninebot Z not available yet</string>
     <string name="reset_top_speed_title_2">Reset Top Speed</string>
     <string name="reset_user_distance_title_2">Reset User Distance</string>
+    <string name="edit_user_distance_title_2">Edit User Distance</string>
     <string name="horn_mode_title">Horn Mode</string>
     <string name="horn_mode_summary">Executed when the select button on the Pebble watch is pressed</string>
     <string name="speech_text_welcome_on_board">Welcome on board!</string>
@@ -338,6 +341,7 @@
     <string name="about_wheellog_title">About WheelLog</string>
     <string name="about_text"><![CDATA[Version %s built at %s<br>by Sebastian Łastowski <a href=\"sebastian@euc.world\">sebastian@euc.world</a><br><br><small>Hey, are you interested in using live map feature? Learn more and register for free at <a href=\"https://euc.world\">https://euc.world</a></small>]]></string>
     <string name="mac_edit_type">MAC Edit</string>
+    <string name="userdist_edit_type">Original Wheel Distance</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="wheel_password">Wheel Password (Inmotion only)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -48,6 +48,11 @@
 		android:enabled="true"
         android:title="@string/reset_user_distance_title" />
 
+	<Preference
+        android:key="@string/edit_user_distance"
+		android:enabled="true"
+        android:title="@string/edit_user_distance_title" />
+
     <Preference
         android:key="@string/last_mac"
         android:enabled="true"

--- a/app/src/main/res/xml/preferences_trip.xml
+++ b/app/src/main/res/xml/preferences_trip.xml
@@ -8,6 +8,11 @@
         android:title="@string/reset_top_speed_title_2" />
 
 	<Preference
+        android:key="@string/edit_user_distance"
+		android:enabled="true"
+        android:title="@string/edit_user_distance_title_2" />
+
+	<Preference
         android:key="@string/reset_user_distance"
 		android:enabled="true"
         android:title="@string/reset_user_distance_title_2" />


### PR DESCRIPTION
This allows the entry of the original wheel distance (as at purchase) and subtracts that from the wheel's total distance, to calculate the user distance. Especially helpful for 2nd hand wheel owners who are still keen to _continuously_ upgrade_ to EUC.world's version of wheellog.

Why the original wheel distance and not the user's current distance, because then you'll only ever have to remember / note down one number, and not keep track of a running total.